### PR TITLE
Async initialization

### DIFF
--- a/Vostok.Applications.Scheduled/Helpers/ScheduledApplicationHelper.cs
+++ b/Vostok.Applications.Scheduled/Helpers/ScheduledApplicationHelper.cs
@@ -9,7 +9,9 @@ namespace Vostok.Applications.Scheduled.Helpers
 {
     internal static class ScheduledApplicationHelper
     {
-        public static async Task<(ScheduledActionsRunner, List<IDisposable>)> InitializeAsync(IVostokHostingEnvironment environment, Func<IScheduledActionsBuilder, IVostokHostingEnvironment, Task> setupRunner)
+        public static async Task<(ScheduledActionsRunner, List<IDisposable>)> InitializeAsync(
+            IVostokHostingEnvironment environment,
+            Func<IScheduledActionsBuilder, IVostokHostingEnvironment, Task> setupRunner)
         {
             var builder = new ScheduledActionsBuilder(environment.Log);
 
@@ -23,7 +25,7 @@ namespace Vostok.Applications.Scheduled.Helpers
         private static List<IDisposable> RegisterDiagnosticFeatures(IVostokHostingEnvironment environment, ScheduledActionsRunner runner)
         {
             var disposables = new List<IDisposable>();
-            
+
             if (!environment.HostExtensions.TryGet<IVostokApplicationDiagnostics>(out var diagnostics))
                 return disposables;
 

--- a/Vostok.Applications.Scheduled/Helpers/ScheduledApplicationHelper.cs
+++ b/Vostok.Applications.Scheduled/Helpers/ScheduledApplicationHelper.cs
@@ -11,6 +11,20 @@ namespace Vostok.Applications.Scheduled.Helpers
     {
         public static async Task<(ScheduledActionsRunner, List<IDisposable>)> InitializeAsync(
             IVostokHostingEnvironment environment,
+            Action<IScheduledActionsBuilder, IVostokHostingEnvironment> setupRunner)
+        {
+            return await InitializeAsync(
+                    environment,
+                    (builder, env) =>
+                    {
+                        setupRunner(builder, env);
+                        return Task.CompletedTask;
+                    })
+               .ConfigureAwait(false);
+        }
+        
+        public static async Task<(ScheduledActionsRunner, List<IDisposable>)> InitializeAsync(
+            IVostokHostingEnvironment environment,
             Func<IScheduledActionsBuilder, IVostokHostingEnvironment, Task> setupRunner)
         {
             var builder = new ScheduledActionsBuilder(environment.Log, environment.Tracer);

--- a/Vostok.Applications.Scheduled/Helpers/ScheduledApplicationHelper.cs
+++ b/Vostok.Applications.Scheduled/Helpers/ScheduledApplicationHelper.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Vostok.Applications.Scheduled.Diagnostics;
+using Vostok.Hosting.Abstractions;
+using Vostok.Hosting.Abstractions.Diagnostics;
+
+namespace Vostok.Applications.Scheduled.Helpers
+{
+    internal static class ScheduledApplicationHelper
+    {
+        public static async Task<(ScheduledActionsRunner, List<IDisposable>)> InitializeAsync(IVostokHostingEnvironment environment, Func<IScheduledActionsBuilder, IVostokHostingEnvironment, Task> setupRunner)
+        {
+            var builder = new ScheduledActionsBuilder(environment.Log);
+
+            await setupRunner(builder, environment).ConfigureAwait(false);
+
+            var runner = builder.BuildRunnerInternal();
+
+            return (runner, RegisterDiagnosticFeatures(environment, runner));
+        }
+
+        private static List<IDisposable> RegisterDiagnosticFeatures(IVostokHostingEnvironment environment, ScheduledActionsRunner runner)
+        {
+            var disposables = new List<IDisposable>();
+            
+            if (!environment.HostExtensions.TryGet<IVostokApplicationDiagnostics>(out var diagnostics))
+                return disposables;
+
+            foreach (var actionRunner in runner.Runners)
+            {
+                var info = actionRunner.GetInfo();
+                var infoEntry = new DiagnosticEntry("scheduled", info.Name);
+                var infoProvider = new ScheduledActionsInfoProvider(actionRunner);
+                var healthCheck = new ScheduledActionsHealthCheck(actionRunner);
+
+                disposables.Add(diagnostics.Info.RegisterProvider(infoEntry, infoProvider));
+                disposables.Add(diagnostics.HealthTracker.RegisterCheck($"scheduled ({info.Name})", healthCheck));
+            }
+
+            return disposables;
+        }
+    }
+}

--- a/Vostok.Applications.Scheduled/VostokScheduledApplication.cs
+++ b/Vostok.Applications.Scheduled/VostokScheduledApplication.cs
@@ -9,11 +9,28 @@ namespace Vostok.Applications.Scheduled
     {
         public abstract void Setup([NotNull] IScheduledActionsBuilder builder, [NotNull] IVostokHostingEnvironment environment);
 
-        public override Task SetupAsync(IScheduledActionsBuilder builder, IVostokHostingEnvironment environment)
+        public sealed override Task SetupAsync(IScheduledActionsBuilder builder, IVostokHostingEnvironment environment)
         {
             Setup(builder, environment);
-            
+
             return Task.CompletedTask;
+        }
+
+        public virtual void DoDispose()
+        {
+        }
+
+        public virtual Task DoDisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        protected sealed override async Task DisposeAsync()
+        {
+            await DoDisposeAsync().ConfigureAwait(false);
+
+            // ReSharper disable once MethodHasAsyncOverload
+            DoDispose();
         }
     }
 }

--- a/Vostok.Applications.Scheduled/VostokScheduledApplication.cs
+++ b/Vostok.Applications.Scheduled/VostokScheduledApplication.cs
@@ -31,7 +31,7 @@ namespace Vostok.Applications.Scheduled
 
         public void Dispose()
         {
-            disposables.ForEach(disposable => disposable.Dispose());
+            disposables?.ForEach(disposable => disposable.Dispose());
             DoDisposeAsync().GetAwaiter().GetResult();
             DoDispose();
         }

--- a/Vostok.Applications.Scheduled/VostokScheduledApplication.cs
+++ b/Vostok.Applications.Scheduled/VostokScheduledApplication.cs
@@ -1,69 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Vostok.Applications.Scheduled.Diagnostics;
 using Vostok.Hosting.Abstractions;
-using Vostok.Hosting.Abstractions.Diagnostics;
 
 namespace Vostok.Applications.Scheduled
 {
     [PublicAPI]
-    public abstract class VostokScheduledApplication : IVostokApplication, IDisposable
+    public abstract class VostokScheduledApplication : VostokScheduledAsyncApplication
     {
-        private readonly List<IDisposable> disposables = new List<IDisposable>();
-
-        private volatile ScheduledActionsRunner runner;
-
         public abstract void Setup([NotNull] IScheduledActionsBuilder builder, [NotNull] IVostokHostingEnvironment environment);
 
-        public Task InitializeAsync(IVostokHostingEnvironment environment)
+        public override Task SetupAsync(IScheduledActionsBuilder builder, IVostokHostingEnvironment environment)
         {
-            var builder = new ScheduledActionsBuilder(environment.Log);
-
             Setup(builder, environment);
-
-            runner = builder.BuildRunnerInternal();
-
-            RegisterDiagnosticFeatures(environment);
-
+            
             return Task.CompletedTask;
-        }
-
-        public Task RunAsync(IVostokHostingEnvironment environment)
-            => runner.RunAsync(environment.ShutdownToken);
-
-        public void Dispose()
-        {
-            disposables.ForEach(disposable => disposable.Dispose());
-            DoDisposeAsync().GetAwaiter().GetResult();
-            DoDispose();
-        }
-
-        public virtual void DoDispose()
-        {
-        }
-
-        public virtual Task DoDisposeAsync()
-        {
-            return Task.CompletedTask;
-        }
-
-        private void RegisterDiagnosticFeatures(IVostokHostingEnvironment environment)
-        {
-            if (!environment.HostExtensions.TryGet<IVostokApplicationDiagnostics>(out var diagnostics))
-                return;
-
-            foreach (var actionRunner in runner.Runners)
-            {
-                var info = actionRunner.GetInfo();
-                var infoEntry = new DiagnosticEntry("scheduled", info.Name);
-                var infoProvider = new ScheduledActionsInfoProvider(actionRunner);
-                var healthCheck = new ScheduledActionsHealthCheck(actionRunner);
-
-                disposables.Add(diagnostics.Info.RegisterProvider(infoEntry, infoProvider));
-                disposables.Add(diagnostics.HealthTracker.RegisterCheck($"scheduled ({info.Name})", healthCheck));
-            }
         }
     }
 }

--- a/Vostok.Applications.Scheduled/VostokScheduledApplication.cs
+++ b/Vostok.Applications.Scheduled/VostokScheduledApplication.cs
@@ -1,20 +1,42 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Vostok.Applications.Scheduled.Helpers;
 using Vostok.Hosting.Abstractions;
 
 namespace Vostok.Applications.Scheduled
 {
     [PublicAPI]
-    public abstract class VostokScheduledApplication : VostokScheduledAsyncApplication
+    public abstract class VostokScheduledApplication : IVostokApplication, IDisposable
     {
-        public abstract void Setup([NotNull] IScheduledActionsBuilder builder, [NotNull] IVostokHostingEnvironment environment);
+        private List<IDisposable> disposables;
 
-        public sealed override Task SetupAsync(IScheduledActionsBuilder builder, IVostokHostingEnvironment environment)
+        private volatile ScheduledActionsRunner runner;
+
+        public async Task InitializeAsync(IVostokHostingEnvironment environment)
         {
-            Setup(builder, environment);
-
-            return Task.CompletedTask;
+            (runner, disposables) = await ScheduledApplicationHelper.InitializeAsync(
+                    environment,
+                    (builder, env) =>
+                    {
+                        Setup(builder, env);
+                        return Task.CompletedTask;
+                    })
+               .ConfigureAwait(false);
         }
+
+        public Task RunAsync(IVostokHostingEnvironment environment)
+            => runner.RunAsync(environment.ShutdownToken);
+
+        public void Dispose()
+        {
+            disposables.ForEach(disposable => disposable.Dispose());
+            DoDisposeAsync().GetAwaiter().GetResult();
+            DoDispose();
+        }
+
+        public abstract void Setup([NotNull] IScheduledActionsBuilder builder, [NotNull] IVostokHostingEnvironment environment);
 
         public virtual void DoDispose()
         {
@@ -23,14 +45,6 @@ namespace Vostok.Applications.Scheduled
         public virtual Task DoDisposeAsync()
         {
             return Task.CompletedTask;
-        }
-
-        protected sealed override async Task DisposeAsync()
-        {
-            await DoDisposeAsync().ConfigureAwait(false);
-
-            // ReSharper disable once MethodHasAsyncOverload
-            DoDispose();
         }
     }
 }

--- a/Vostok.Applications.Scheduled/VostokScheduledApplication.cs
+++ b/Vostok.Applications.Scheduled/VostokScheduledApplication.cs
@@ -18,12 +18,8 @@ namespace Vostok.Applications.Scheduled
         {
             (runner, disposables) = await ScheduledApplicationHelper.InitializeAsync(
                     environment,
-                    (builder, env) =>
-                    {
-                        Setup(builder, env);
-                        return Task.CompletedTask;
-                    })
-                .ConfigureAwait(false);
+                    (builder, env) => Setup(builder, env))
+               .ConfigureAwait(false);
         }
 
         public Task RunAsync(IVostokHostingEnvironment environment)

--- a/Vostok.Applications.Scheduled/VostokScheduledAsyncApplication.cs
+++ b/Vostok.Applications.Scheduled/VostokScheduledAsyncApplication.cs
@@ -24,7 +24,7 @@ namespace Vostok.Applications.Scheduled
 
         public void Dispose()
         {
-            disposables.ForEach(disposable => disposable.Dispose());
+            disposables?.ForEach(disposable => disposable.Dispose());
             DoDisposeAsync().GetAwaiter().GetResult();
         }
 

--- a/Vostok.Applications.Scheduled/VostokScheduledAsyncApplication.cs
+++ b/Vostok.Applications.Scheduled/VostokScheduledAsyncApplication.cs
@@ -2,30 +2,21 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Vostok.Applications.Scheduled.Diagnostics;
+using Vostok.Applications.Scheduled.Helpers;
 using Vostok.Hosting.Abstractions;
-using Vostok.Hosting.Abstractions.Diagnostics;
 
 namespace Vostok.Applications.Scheduled
 {
     [PublicAPI]
     public abstract class VostokScheduledAsyncApplication : IVostokApplication, IDisposable
     {
-        private readonly List<IDisposable> disposables = new List<IDisposable>();
+        private List<IDisposable> disposables;
 
         private volatile ScheduledActionsRunner runner;
 
-        public abstract Task SetupAsync([NotNull] IScheduledActionsBuilder builder, [NotNull] IVostokHostingEnvironment environment);
-
         public async Task InitializeAsync(IVostokHostingEnvironment environment)
         {
-            var builder = new ScheduledActionsBuilder(environment.Log);
-
-            await SetupAsync(builder, environment).ConfigureAwait(false);
-
-            runner = builder.BuildRunnerInternal();
-
-            RegisterDiagnosticFeatures(environment);
+            (runner, disposables) = await ScheduledApplicationHelper.InitializeAsync(environment, SetupAsync).ConfigureAwait(false);
         }
 
         public Task RunAsync(IVostokHostingEnvironment environment)
@@ -34,29 +25,14 @@ namespace Vostok.Applications.Scheduled
         public void Dispose()
         {
             disposables.ForEach(disposable => disposable.Dispose());
-            DisposeAsync().GetAwaiter().GetResult();
+            DoDisposeAsync().GetAwaiter().GetResult();
         }
 
-        protected virtual Task DisposeAsync()
+        protected abstract Task SetupAsync([NotNull] IScheduledActionsBuilder builder, [NotNull] IVostokHostingEnvironment environment);
+
+        protected virtual Task DoDisposeAsync()
         {
             return Task.CompletedTask;
-        }
-
-        private void RegisterDiagnosticFeatures(IVostokHostingEnvironment environment)
-        {
-            if (!environment.HostExtensions.TryGet<IVostokApplicationDiagnostics>(out var diagnostics))
-                return;
-
-            foreach (var actionRunner in runner.Runners)
-            {
-                var info = actionRunner.GetInfo();
-                var infoEntry = new DiagnosticEntry("scheduled", info.Name);
-                var infoProvider = new ScheduledActionsInfoProvider(actionRunner);
-                var healthCheck = new ScheduledActionsHealthCheck(actionRunner);
-
-                disposables.Add(diagnostics.Info.RegisterProvider(infoEntry, infoProvider));
-                disposables.Add(diagnostics.HealthTracker.RegisterCheck($"scheduled ({info.Name})", healthCheck));
-            }
         }
     }
 }

--- a/Vostok.Applications.Scheduled/VostokScheduledAsyncApplication.cs
+++ b/Vostok.Applications.Scheduled/VostokScheduledAsyncApplication.cs
@@ -21,7 +21,7 @@ namespace Vostok.Applications.Scheduled
         {
             var builder = new ScheduledActionsBuilder(environment.Log);
 
-            await SetupAsync(builder, environment);
+            await SetupAsync(builder, environment).ConfigureAwait(false);
 
             runner = builder.BuildRunnerInternal();
 

--- a/Vostok.Applications.Scheduled/VostokScheduledAsyncApplication.cs
+++ b/Vostok.Applications.Scheduled/VostokScheduledAsyncApplication.cs
@@ -34,15 +34,10 @@ namespace Vostok.Applications.Scheduled
         public void Dispose()
         {
             disposables.ForEach(disposable => disposable.Dispose());
-            DoDisposeAsync().GetAwaiter().GetResult();
-            DoDispose();
+            DisposeAsync().GetAwaiter().GetResult();
         }
 
-        public virtual void DoDispose()
-        {
-        }
-
-        public virtual Task DoDisposeAsync()
+        protected virtual Task DisposeAsync()
         {
             return Task.CompletedTask;
         }

--- a/Vostok.Applications.Scheduled/VostokScheduledAsyncApplication.cs
+++ b/Vostok.Applications.Scheduled/VostokScheduledAsyncApplication.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Vostok.Applications.Scheduled.Diagnostics;
+using Vostok.Hosting.Abstractions;
+using Vostok.Hosting.Abstractions.Diagnostics;
+
+namespace Vostok.Applications.Scheduled
+{
+    [PublicAPI]
+    public abstract class VostokScheduledAsyncApplication : IVostokApplication, IDisposable
+    {
+        private readonly List<IDisposable> disposables = new List<IDisposable>();
+
+        private volatile ScheduledActionsRunner runner;
+
+        public abstract Task SetupAsync([NotNull] IScheduledActionsBuilder builder, [NotNull] IVostokHostingEnvironment environment);
+
+        public async Task InitializeAsync(IVostokHostingEnvironment environment)
+        {
+            var builder = new ScheduledActionsBuilder(environment.Log);
+
+            await SetupAsync(builder, environment);
+
+            runner = builder.BuildRunnerInternal();
+
+            RegisterDiagnosticFeatures(environment);
+        }
+
+        public Task RunAsync(IVostokHostingEnvironment environment)
+            => runner.RunAsync(environment.ShutdownToken);
+
+        public void Dispose()
+        {
+            disposables.ForEach(disposable => disposable.Dispose());
+            DoDisposeAsync().GetAwaiter().GetResult();
+            DoDispose();
+        }
+
+        public virtual void DoDispose()
+        {
+        }
+
+        public virtual Task DoDisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        private void RegisterDiagnosticFeatures(IVostokHostingEnvironment environment)
+        {
+            if (!environment.HostExtensions.TryGet<IVostokApplicationDiagnostics>(out var diagnostics))
+                return;
+
+            foreach (var actionRunner in runner.Runners)
+            {
+                var info = actionRunner.GetInfo();
+                var infoEntry = new DiagnosticEntry("scheduled", info.Name);
+                var infoProvider = new ScheduledActionsInfoProvider(actionRunner);
+                var healthCheck = new ScheduledActionsHealthCheck(actionRunner);
+
+                disposables.Add(diagnostics.Info.RegisterProvider(infoEntry, infoProvider));
+                disposables.Add(diagnostics.HealthTracker.RegisterCheck($"scheduled ({info.Name})", healthCheck));
+            }
+        }
+    }
+}


### PR DESCRIPTION
I suggest adding VostokScheduledAsyncApplication.

There are 2 reasons for this:
1) Users don't have to override both Async and NonAsync versions of Setup method.
2) There are no problems with ordering method execution, because we have only one setup in each class. 